### PR TITLE
feat: #1 Auth Service 보일러플레이트 초기 구성

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,44 @@
+HELP.md
+.gradle
+build/
+!gradle/wrapper/gradle-wrapper.jar
+!**/src/main/**/build/
+!**/src/test/**/build/
+
+### STS ###
+.apt_generated
+.classpath
+.factorypath
+.project
+.settings
+.springBeans
+.sts4-cache
+bin/
+!**/src/main/**/bin/
+!**/src/test/**/bin/
+
+### IntelliJ IDEA ###
+.idea
+*.iws
+*.iml
+*.ipr
+out/
+!**/src/main/**/out/
+!**/src/test/**/out/
+
+### NetBeans ###
+/nbproject/private/
+/nbbuild/
+/dist/
+/nbdist/
+/.nb-gradle/
+
+### VS Code ###
+.vscode/
+
+### macOS ###
+.DS_Store
+
+### Environment ###
+.env
+*.env.local

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,37 @@
+## ---------- Build Stage ----------
+FROM eclipse-temurin:21-jdk AS builder
+
+WORKDIR /app
+
+COPY gradle/ gradle/
+COPY gradlew .
+COPY build.gradle .
+COPY settings.gradle .
+
+RUN chmod +x gradlew
+RUN ./gradlew dependencies --no-daemon || true
+
+COPY src/ src/
+
+RUN ./gradlew bootJar --no-daemon -x test
+
+## ---------- Runtime Stage ----------
+FROM eclipse-temurin:21-jre
+
+WORKDIR /app
+
+RUN groupadd -r appuser && useradd -r -g appuser appuser
+
+COPY --from=builder /app/build/libs/*.jar app.jar
+
+RUN chown appuser:appuser app.jar
+
+USER appuser
+
+EXPOSE 8081
+
+ENTRYPOINT ["java", \
+    "-XX:+UseContainerSupport", \
+    "-XX:MaxRAMPercentage=75.0", \
+    "-Djava.security.egd=file:/dev/./urandom", \
+    "-jar", "app.jar"]

--- a/build.gradle
+++ b/build.gradle
@@ -1,0 +1,65 @@
+plugins {
+    id 'java'
+    id 'org.springframework.boot' version '3.5.10'
+    id 'io.spring.dependency-management' version '1.1.7'
+}
+
+group = 'com.opentraum'
+version = '0.0.1-SNAPSHOT'
+
+java {
+    toolchain {
+        languageVersion = JavaLanguageVersion.of(21)
+    }
+}
+
+configurations {
+    compileOnly {
+        extendsFrom annotationProcessor
+    }
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    // Spring Boot WebFlux (Reactive)
+    implementation 'org.springframework.boot:spring-boot-starter-webflux'
+
+    // Spring Security (Reactive)
+    implementation 'org.springframework.boot:spring-boot-starter-security'
+
+    // R2DBC - PostgreSQL
+    implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
+    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+
+    // Redis Reactive
+    implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'
+
+    // JWT (jjwt)
+    implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+    runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
+    // Actuator + Prometheus
+    implementation 'org.springframework.boot:spring-boot-starter-actuator'
+    runtimeOnly 'io.micrometer:micrometer-registry-prometheus'
+
+    // Validation
+    implementation 'org.springframework.boot:spring-boot-starter-validation'
+
+    // Lombok
+    compileOnly 'org.projectlombok:lombok'
+    annotationProcessor 'org.projectlombok:lombok'
+
+    // Test
+    testImplementation 'org.springframework.boot:spring-boot-starter-test'
+    testImplementation 'io.projectreactor:reactor-test'
+    testImplementation 'org.springframework.security:spring-security-test'
+    testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+tasks.named('test') {
+    useJUnitPlatform()
+}

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,0 +1,7 @@
+distributionBase=GRADLE_USER_HOME
+distributionPath=wrapper/dists
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.12-bin.zip
+networkTimeout=10000
+validateDistributionUrl=true
+zipStoreBase=GRADLE_USER_HOME
+zipStorePath=wrapper/dists

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,0 +1,1 @@
+rootProject.name = 'opentraum-auth-service'

--- a/src/main/java/com/opentraum/auth/AuthServiceApplication.java
+++ b/src/main/java/com/opentraum/auth/AuthServiceApplication.java
@@ -1,0 +1,12 @@
+package com.opentraum.auth;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+@SpringBootApplication
+public class AuthServiceApplication {
+
+    public static void main(String[] args) {
+        SpringApplication.run(AuthServiceApplication.class, args);
+    }
+}

--- a/src/main/java/com/opentraum/auth/config/R2dbcConfig.java
+++ b/src/main/java/com/opentraum/auth/config/R2dbcConfig.java
@@ -1,0 +1,11 @@
+package com.opentraum.auth.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.r2dbc.config.EnableR2dbcAuditing;
+import org.springframework.data.r2dbc.repository.config.EnableR2dbcRepositories;
+
+@Configuration
+@EnableR2dbcAuditing
+@EnableR2dbcRepositories(basePackages = "com.opentraum.auth.domain.repository")
+public class R2dbcConfig {
+}

--- a/src/main/java/com/opentraum/auth/config/RedisConfig.java
+++ b/src/main/java/com/opentraum/auth/config/RedisConfig.java
@@ -1,0 +1,25 @@
+package com.opentraum.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.ReactiveRedisConnectionFactory;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.data.redis.serializer.RedisSerializationContext;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@Configuration
+public class RedisConfig {
+
+    @Bean
+    public ReactiveRedisTemplate<String, String> reactiveRedisTemplate(
+            ReactiveRedisConnectionFactory connectionFactory) {
+
+        RedisSerializationContext<String, String> serializationContext =
+                RedisSerializationContext.<String, String>newSerializationContext(new StringRedisSerializer())
+                        .hashKey(new StringRedisSerializer())
+                        .hashValue(new StringRedisSerializer())
+                        .build();
+
+        return new ReactiveRedisTemplate<>(connectionFactory, serializationContext);
+    }
+}

--- a/src/main/java/com/opentraum/auth/config/SecurityConfig.java
+++ b/src/main/java/com/opentraum/auth/config/SecurityConfig.java
@@ -1,0 +1,33 @@
+package com.opentraum.auth.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.reactive.EnableWebFluxSecurity;
+import org.springframework.security.config.web.server.ServerHttpSecurity;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.crypto.password.PasswordEncoder;
+import org.springframework.security.web.server.SecurityWebFilterChain;
+
+@Configuration
+@EnableWebFluxSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityWebFilterChain securityWebFilterChain(ServerHttpSecurity http) {
+        return http
+                .csrf(ServerHttpSecurity.CsrfSpec::disable)
+                .formLogin(ServerHttpSecurity.FormLoginSpec::disable)
+                .httpBasic(ServerHttpSecurity.HttpBasicSpec::disable)
+                .authorizeExchange(exchanges -> exchanges
+                        .pathMatchers("/api/v1/auth/**").permitAll()
+                        .pathMatchers("/actuator/**").permitAll()
+                        .anyExchange().authenticated()
+                )
+                .build();
+    }
+
+    @Bean
+    public PasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/src/main/java/com/opentraum/auth/domain/controller/AuthController.java
+++ b/src/main/java/com/opentraum/auth/domain/controller/AuthController.java
@@ -1,0 +1,58 @@
+package com.opentraum.auth.domain.controller;
+
+import com.opentraum.auth.domain.dto.LoginRequest;
+import com.opentraum.auth.domain.dto.LoginResponse;
+import com.opentraum.auth.domain.dto.TokenRefreshRequest;
+import com.opentraum.auth.domain.service.AuthService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Mono;
+
+@RestController
+@RequestMapping("/api/v1/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 로그인
+     * POST /api/v1/auth/login
+     */
+    @PostMapping("/login")
+    public Mono<ResponseEntity<LoginResponse>> login(@Valid @RequestBody LoginRequest request) {
+        return authService.login(request)
+                .map(response -> ResponseEntity.ok(response));
+    }
+
+    /**
+     * 토큰 갱신
+     * POST /api/v1/auth/refresh
+     */
+    @PostMapping("/refresh")
+    public Mono<ResponseEntity<LoginResponse>> refresh(@Valid @RequestBody TokenRefreshRequest request) {
+        return authService.refresh(request)
+                .map(response -> ResponseEntity.ok(response));
+    }
+
+    /**
+     * 로그아웃
+     * POST /api/v1/auth/logout
+     */
+    @PostMapping("/logout")
+    public Mono<ResponseEntity<Void>> logout(
+            @RequestHeader("Authorization") String authorization,
+            @RequestBody TokenRefreshRequest request) {
+
+        String accessToken = authorization.replace("Bearer ", "");
+        return authService.logout(accessToken, request.refreshToken())
+                .then(Mono.just(ResponseEntity.status(HttpStatus.NO_CONTENT).<Void>build()));
+    }
+}

--- a/src/main/java/com/opentraum/auth/domain/dto/LoginRequest.java
+++ b/src/main/java/com/opentraum/auth/domain/dto/LoginRequest.java
@@ -1,0 +1,17 @@
+package com.opentraum.auth.domain.dto;
+
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
+
+public record LoginRequest(
+        @NotBlank(message = "이메일은 필수 입력값입니다.")
+        @Email(message = "올바른 이메일 형식이 아닙니다.")
+        String email,
+
+        @NotBlank(message = "비밀번호는 필수 입력값입니다.")
+        String password,
+
+        @NotBlank(message = "테넌트 ID는 필수 입력값입니다.")
+        String tenantId
+) {
+}

--- a/src/main/java/com/opentraum/auth/domain/dto/LoginResponse.java
+++ b/src/main/java/com/opentraum/auth/domain/dto/LoginResponse.java
@@ -1,0 +1,7 @@
+package com.opentraum.auth.domain.dto;
+
+public record LoginResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/src/main/java/com/opentraum/auth/domain/dto/TokenRefreshRequest.java
+++ b/src/main/java/com/opentraum/auth/domain/dto/TokenRefreshRequest.java
@@ -1,0 +1,9 @@
+package com.opentraum.auth.domain.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record TokenRefreshRequest(
+        @NotBlank(message = "리프레시 토큰은 필수 입력값입니다.")
+        String refreshToken
+) {
+}

--- a/src/main/java/com/opentraum/auth/domain/entity/Auth.java
+++ b/src/main/java/com/opentraum/auth/domain/entity/Auth.java
@@ -1,0 +1,41 @@
+package com.opentraum.auth.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("auth_refresh_tokens")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Auth {
+
+    @Id
+    private Long id;
+
+    @Column("user_id")
+    private Long userId;
+
+    @Column("refresh_token")
+    private String refreshToken;
+
+    @Column("tenant_id")
+    private String tenantId;
+
+    @CreatedDate
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @Column("expires_at")
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/opentraum/auth/domain/repository/AuthRepository.java
+++ b/src/main/java/com/opentraum/auth/domain/repository/AuthRepository.java
@@ -1,0 +1,18 @@
+package com.opentraum.auth.domain.repository;
+
+import com.opentraum.auth.domain.entity.Auth;
+import org.springframework.data.r2dbc.repository.R2dbcRepository;
+import org.springframework.stereotype.Repository;
+import reactor.core.publisher.Mono;
+
+@Repository
+public interface AuthRepository extends R2dbcRepository<Auth, Long> {
+
+    Mono<Auth> findByRefreshToken(String refreshToken);
+
+    Mono<Auth> findByUserIdAndTenantId(Long userId, String tenantId);
+
+    Mono<Void> deleteByRefreshToken(String refreshToken);
+
+    Mono<Void> deleteByUserId(Long userId);
+}

--- a/src/main/java/com/opentraum/auth/domain/service/AuthService.java
+++ b/src/main/java/com/opentraum/auth/domain/service/AuthService.java
@@ -1,0 +1,27 @@
+package com.opentraum.auth.domain.service;
+
+import com.opentraum.auth.domain.dto.LoginRequest;
+import com.opentraum.auth.domain.dto.LoginResponse;
+import com.opentraum.auth.domain.dto.TokenRefreshRequest;
+import reactor.core.publisher.Mono;
+
+public interface AuthService {
+
+    /**
+     * 로그인 처리
+     * - 사용자 인증 후 access/refresh 토큰 발급
+     */
+    Mono<LoginResponse> login(LoginRequest request);
+
+    /**
+     * 토큰 갱신
+     * - refresh 토큰 검증 후 새로운 access/refresh 토큰 발급
+     */
+    Mono<LoginResponse> refresh(TokenRefreshRequest request);
+
+    /**
+     * 로그아웃 처리
+     * - refresh 토큰 삭제 및 access 토큰 블랙리스트 등록
+     */
+    Mono<Void> logout(String accessToken, String refreshToken);
+}

--- a/src/main/java/com/opentraum/auth/domain/service/AuthServiceImpl.java
+++ b/src/main/java/com/opentraum/auth/domain/service/AuthServiceImpl.java
@@ -1,0 +1,51 @@
+package com.opentraum.auth.domain.service;
+
+import com.opentraum.auth.domain.dto.LoginRequest;
+import com.opentraum.auth.domain.dto.LoginResponse;
+import com.opentraum.auth.domain.dto.TokenRefreshRequest;
+import com.opentraum.auth.domain.repository.AuthRepository;
+import com.opentraum.auth.util.JwtProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.core.ReactiveRedisTemplate;
+import org.springframework.stereotype.Service;
+import reactor.core.publisher.Mono;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+public class AuthServiceImpl implements AuthService {
+
+    private final AuthRepository authRepository;
+    private final JwtProvider jwtProvider;
+    private final ReactiveRedisTemplate<String, String> reactiveRedisTemplate;
+
+    @Override
+    public Mono<LoginResponse> login(LoginRequest request) {
+        // TODO: User Service 연동 후 구현
+        // 1. User Service에 사용자 인증 요청 (WebClient)
+        // 2. 인증 성공 시 access/refresh 토큰 생성
+        // 3. refresh 토큰을 DB 및 Redis에 저장
+        // 4. LoginResponse 반환
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<LoginResponse> refresh(TokenRefreshRequest request) {
+        // TODO: 구현 예정
+        // 1. refresh 토큰 유효성 검증
+        // 2. DB에서 refresh 토큰 조회
+        // 3. 새로운 access/refresh 토큰 생성
+        // 4. 기존 refresh 토큰 폐기 및 신규 저장 (Rotation)
+        // 5. LoginResponse 반환
+        return Mono.empty();
+    }
+
+    @Override
+    public Mono<Void> logout(String accessToken, String refreshToken) {
+        // TODO: 구현 예정
+        // 1. access 토큰을 Redis 블랙리스트에 등록 (남은 TTL만큼)
+        // 2. refresh 토큰을 DB 및 Redis에서 삭제
+        return Mono.empty();
+    }
+}

--- a/src/main/java/com/opentraum/auth/util/JwtProvider.java
+++ b/src/main/java/com/opentraum/auth/util/JwtProvider.java
@@ -1,0 +1,122 @@
+package com.opentraum.auth.util;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.JwtException;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import jakarta.annotation.PostConstruct;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtProvider {
+
+    @Value("${jwt.secret}")
+    private String secret;
+
+    @Value("${jwt.access-token-expiration}")
+    private long accessTokenExpiration;
+
+    @Value("${jwt.refresh-token-expiration}")
+    private long refreshTokenExpiration;
+
+    private SecretKey key;
+
+    @PostConstruct
+    public void init() {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+    }
+
+    /**
+     * Access Token 생성
+     */
+    public String generateAccessToken(Long userId, String tenantId, String role) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("tenantId", tenantId)
+                .claim("role", role)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Refresh Token 생성
+     */
+    public String generateRefreshToken(Long userId, String tenantId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + refreshTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .claim("tenantId", tenantId)
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * 토큰에서 Claims 추출
+     */
+    public Claims getClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+
+    /**
+     * 토큰 유효성 검증
+     */
+    public boolean validateToken(String token) {
+        try {
+            getClaims(token);
+            return true;
+        } catch (JwtException | IllegalArgumentException e) {
+            log.warn("Invalid JWT token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    /**
+     * 토큰에서 사용자 ID 추출
+     */
+    public Long getUserId(String token) {
+        return Long.parseLong(getClaims(token).getSubject());
+    }
+
+    /**
+     * 토큰에서 테넌트 ID 추출
+     */
+    public String getTenantId(String token) {
+        return getClaims(token).get("tenantId", String.class);
+    }
+
+    /**
+     * 토큰의 남은 유효 시간 (밀리초)
+     */
+    public long getRemainingExpiration(String token) {
+        Date expiration = getClaims(token).getExpiration();
+        return expiration.getTime() - System.currentTimeMillis();
+    }
+
+    public long getAccessTokenExpiration() {
+        return accessTokenExpiration;
+    }
+
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,66 @@
+server:
+  port: 8081
+
+spring:
+  application:
+    name: opentraum-auth-service
+
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:opentraum_auth}
+    username: ${DB_USERNAME:postgres}
+    password: ${DB_PASSWORD:postgres}
+
+  data:
+    redis:
+      host: ${REDIS_HOST:localhost}
+      port: ${REDIS_PORT:6379}
+      password: ${REDIS_PASSWORD:}
+
+  sql:
+    init:
+      mode: always
+      schema-locations: classpath:schema.sql
+
+jwt:
+  secret: ${JWT_SECRET:opentraum-default-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256}
+  access-token-expiration: ${JWT_ACCESS_EXPIRATION:1800000}   # 30분 (밀리초)
+  refresh-token-expiration: ${JWT_REFRESH_EXPIRATION:604800000} # 7일 (밀리초)
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health, info, prometheus, metrics
+  endpoint:
+    health:
+      show-details: always
+  metrics:
+    tags:
+      application: ${spring.application.name}
+
+logging:
+  level:
+    root: INFO
+    com.opentraum.auth: DEBUG
+    org.springframework.r2dbc: DEBUG
+
+---
+spring:
+  config:
+    activate:
+      on-profile: prod
+
+  r2dbc:
+    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    username: ${DB_USERNAME}
+    password: ${DB_PASSWORD}
+
+  sql:
+    init:
+      mode: never
+
+logging:
+  level:
+    root: WARN
+    com.opentraum.auth: INFO
+    org.springframework.r2dbc: WARN

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,0 +1,20 @@
+CREATE TABLE IF NOT EXISTS auth_refresh_tokens (
+    id          BIGSERIAL       PRIMARY KEY,
+    user_id     BIGINT          NOT NULL,
+    refresh_token VARCHAR(512) NOT NULL UNIQUE,
+    tenant_id   VARCHAR(64)     NOT NULL,
+    created_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
+    expires_at  TIMESTAMP       NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_user_id
+    ON auth_refresh_tokens (user_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_tenant_id
+    ON auth_refresh_tokens (tenant_id);
+
+CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_refresh_token
+    ON auth_refresh_tokens (refresh_token);
+
+CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_expires_at
+    ON auth_refresh_tokens (expires_at);


### PR DESCRIPTION
## 요약
OpenTraum 멀티 테넌시 B2B2C 티켓팅 플랫폼의 **인증/인가 마이크로서비스(Auth Service)** 보일러플레이트를 초기 구성합니다.

Closes #1

## 변경 사항

### 프로젝트 구조
- Spring Boot 3.5.10 + Java 21 + WebFlux(Reactive) 기반 프로젝트 생성
- Gradle 8.12 (Groovy DSL) 빌드 시스템 구성
- Multi-stage Dockerfile 작성

### 핵심 의존성
- **Spring WebFlux** — 리액티브 웹 프레임워크
- **Spring Security (Reactive)** — 인증/인가 처리
- **R2DBC + PostgreSQL** — 리액티브 DB 접근
- **Redis Reactive** — 토큰 블랙리스트 및 리프레시 토큰 캐시
- **jjwt 0.12.6** — JWT 토큰 생성/검증
- **Actuator + Prometheus** — 헬스체크 및 메트릭 수집

### 설정 클래스 (config/)
- SecurityConfig — Reactive Security 설정 (인증 경로 공개)
- R2dbcConfig — R2DBC Auditing 및 Repository 스캔 설정
- RedisConfig — ReactiveRedisTemplate Bean 등록

### 도메인 레이어 (domain/)
- Auth Entity — 리프레시 토큰 저장 (id, userId, refreshToken, tenantId, createdAt, expiresAt)
- AuthRepository — R2DBC Repository
- LoginRequest/LoginResponse/TokenRefreshRequest — DTO (Java Record)
- AuthService Interface + AuthServiceImpl 스켈레톤
- AuthController — REST API
  - POST /api/v1/auth/login
  - POST /api/v1/auth/refresh
  - POST /api/v1/auth/logout

### 유틸리티 (util/)
- JwtProvider — JWT 토큰 생성(access/refresh), 검증, Claims 추출

### 리소스
- application.yml — 포트 8081, 프로파일(default/prod) 분리
- schema.sql — auth_refresh_tokens 테이블 DDL + 인덱스

## 설계 포인트
- **멀티 테넌시**: tenantId를 JWT claims 및 DB에 포함하여 테넌트별 격리
- **Reactive Stack**: WebFlux + R2DBC + Redis Reactive로 전 구간 Non-blocking I/O

## 테스트 계획
- [ ] 프로젝트 빌드 성공 확인 (`./gradlew build`)
- [ ] Docker 이미지 빌드 확인
- [ ] Actuator 헬스체크 엔드포인트 응답 확인
- [ ] JWT 토큰 생성/검증 동작 확인