### PR TITLE
feat: PostgreSQL → MariaDB 전환

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -30,9 +30,9 @@ dependencies {
     // Spring Security (Reactive)
     implementation 'org.springframework.boot:spring-boot-starter-security'
 
-    // R2DBC - PostgreSQL
+    // R2DBC - MariaDB
     implementation 'org.springframework.boot:spring-boot-starter-data-r2dbc'
-    runtimeOnly 'org.postgresql:r2dbc-postgresql'
+    runtimeOnly 'io.asyncer:r2dbc-mysql:1.1.0'
 
     // Redis Reactive
     implementation 'org.springframework.boot:spring-boot-starter-data-redis-reactive'

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -6,9 +6,9 @@ spring:
     name: opentraum-auth-service
 
   r2dbc:
-    url: r2dbc:postgresql://${DB_HOST:localhost}:${DB_PORT:5432}/${DB_NAME:opentraum_auth}
-    username: ${DB_USERNAME:postgres}
-    password: ${DB_PASSWORD:postgres}
+    url: r2dbc:mariadb://${DB_HOST:opentraum-mariadb}:${DB_PORT:3306}/${DB_NAME:opentraum_auth}
+    username: ${DB_USERNAME:opentraum}
+    password: ${DB_PASSWORD:opentraum123!}
 
   data:
     redis:
@@ -57,7 +57,7 @@ spring:
       on-profile: prod
 
   r2dbc:
-    url: r2dbc:postgresql://${DB_HOST}:${DB_PORT}/${DB_NAME}
+    url: r2dbc:mariadb://${DB_HOST}:${DB_PORT}/${DB_NAME}
     username: ${DB_USERNAME}
     password: ${DB_PASSWORD}
 

--- a/src/main/resources/schema.sql
+++ b/src/main/resources/schema.sql
@@ -1,6 +1,6 @@
 -- Users 테이블 (auth-service 로컬 읽기 모델)
 CREATE TABLE IF NOT EXISTS users (
-    id          BIGSERIAL       PRIMARY KEY,
+    id          BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     email       VARCHAR(255)    NOT NULL UNIQUE,
     password    VARCHAR(255)    NOT NULL,
     name        VARCHAR(100)    NOT NULL,
@@ -8,33 +8,21 @@ CREATE TABLE IF NOT EXISTS users (
     role        VARCHAR(20)     NOT NULL DEFAULT 'CONSUMER',
     tenant_id   VARCHAR(64),
     created_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
-    updated_at  TIMESTAMP       NOT NULL DEFAULT NOW()
+    updated_at  TIMESTAMP       NOT NULL DEFAULT NOW(),
+    INDEX idx_users_email (email),
+    INDEX idx_users_tenant_id (tenant_id)
 );
-
-CREATE INDEX IF NOT EXISTS idx_users_email
-    ON users (email);
-
-CREATE INDEX IF NOT EXISTS idx_users_tenant_id
-    ON users (tenant_id);
 
 -- Refresh Token 테이블
 CREATE TABLE IF NOT EXISTS auth_refresh_tokens (
-    id              BIGSERIAL       PRIMARY KEY,
+    id              BIGINT          NOT NULL AUTO_INCREMENT PRIMARY KEY,
     user_id         BIGINT          NOT NULL,
     refresh_token   VARCHAR(512)    NOT NULL UNIQUE,
     tenant_id       VARCHAR(64)     NOT NULL,
     created_at      TIMESTAMP       NOT NULL DEFAULT NOW(),
-    expires_at      TIMESTAMP       NOT NULL
+    expires_at      TIMESTAMP       NOT NULL,
+    INDEX idx_auth_refresh_tokens_user_id (user_id),
+    INDEX idx_auth_refresh_tokens_tenant_id (tenant_id),
+    INDEX idx_auth_refresh_tokens_refresh_token (refresh_token),
+    INDEX idx_auth_refresh_tokens_expires_at (expires_at)
 );
-
-CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_user_id
-    ON auth_refresh_tokens (user_id);
-
-CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_tenant_id
-    ON auth_refresh_tokens (tenant_id);
-
-CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_refresh_token
-    ON auth_refresh_tokens (refresh_token);
-
-CREATE INDEX IF NOT EXISTS idx_auth_refresh_tokens_expires_at
-    ON auth_refresh_tokens (expires_at);


### PR DESCRIPTION
## Summary
- PostgreSQL → MariaDB R2DBC 드라이버 전환
- SKALA 미니프로젝트 1+2 (대량 요청 처리 + CDC) 대비

## Changes
- `r2dbc-postgresql` → `io.asyncer:r2dbc-mysql:1.1.0`
- connection string → `r2dbc:mariadb://opentraum-mariadb:3306`
- schema.sql MariaDB 호환 문법 전환

## Test plan
- [x] MariaDB Pod Running 확인
- [x] 서비스 Pod Running 확인 (새 이미지)
- [ ] /actuator/health 200 응답 확인
- [ ] CRUD API 정상 동작 확인