### PR TITLE
feat: k8s 매니페스트 운영 설정 반영

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -9,6 +9,11 @@ metadata:
     app.kubernetes.io/component: auth
 spec:
   replicas: 1
+  strategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxSurge: 1
+      maxUnavailable: 0
   selector:
     matchLabels:
       app: auth-service
@@ -19,7 +24,14 @@ spec:
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: auth
     spec:
-      terminationGracePeriodSeconds: 10
+      terminationGracePeriodSeconds: 40
+      topologySpreadConstraints:
+        - maxSkew: 1
+          topologyKey: kubernetes.io/hostname
+          whenUnsatisfiable: ScheduleAnyway
+          labelSelector:
+            matchLabels:
+              app: auth-service
       imagePullSecrets:
         - name: harbor-secret
       priorityClassName: opentraum-medium
@@ -49,7 +61,7 @@ spec:
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
-              value: "true"
+              value: "false"
           resources:
             requests:
               memory: "512Mi"


### PR DESCRIPTION
## Summary
- RollingUpdate 전략 추가 (maxSurge=1, maxUnavailable=0): 무중단 배포 보장
- topologySpreadConstraints 추가: 여러 노드에 Pod 분산 (단일 노드 장애 대비)
- terminationGracePeriodSeconds 10 → 40: SIGTERM 후 in-flight 요청 처리 시간 확보
- SPRING_MAIN_LAZY_INITIALIZATION true → false: 첫 요청 지연 제거 (warm-up은 startupProbe로 처리)

## Why
ArgoCD GitOps 자동 배포 전환 (#21)을 위해 운영 환경에서 안정적인 배포·기동을 보장하는 K8s 매니페스트 설정을 반영합니다.

## Test plan
- [ ] PR 머지 후 ArgoCD가 main 브랜치 매니페스트로 자동 sync 되는지 확인
- [ ] 롤링 업데이트 동작 시 0 다운타임 확인
- [ ] Pod 재시작 시 startupProbe 통과 후 트래픽 수신 확인

Closes #21