### PR TITLE
feat: k8s 매니페스트 운영 설정 반영 (Secret + Redis + resources)

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -5,10 +5,12 @@ metadata:
   namespace: opentraum
   labels:
     app: auth-service
+    app.kubernetes.io/name: auth-service
     app.kubernetes.io/part-of: opentraum
     app.kubernetes.io/component: auth
 spec:
   replicas: 1
+  revisionHistoryLimit: 2
   strategy:
     type: RollingUpdate
     rollingUpdate:
@@ -21,6 +23,7 @@ spec:
     metadata:
       labels:
         app: auth-service
+        app.kubernetes.io/name: auth-service
         app.kubernetes.io/part-of: opentraum
         app.kubernetes.io/component: auth
     spec:
@@ -53,22 +56,32 @@ spec:
             - name: DB_NAME
               value: "opentraum_auth"
             - name: DB_USERNAME
-              value: "opentraum"
+              valueFrom:
+                secretKeyRef:
+                  name: auth-db-secret
+                  key: username
             - name: DB_PASSWORD
-              value: "opentraum123!"
+              valueFrom:
+                secretKeyRef:
+                  name: auth-db-secret
+                  key: password
             - name: SPRING_R2DBC_URL
               value: "r2dbc:mysql://opentraum-mariadb.mariadb:3306/opentraum_auth"
+            - name: REDIS_HOST
+              value: "opentraum-redis.redis"
+            - name: REDIS_PORT
+              value: "6379"
             - name: JAVA_OPTS
               value: "-XX:+UseContainerSupport -XX:MaxRAMPercentage=75.0 -XX:+TieredCompilation -XX:TieredStopAtLevel=1"
             - name: SPRING_MAIN_LAZY_INITIALIZATION
               value: "false"
           resources:
             requests:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "256Mi"
+              cpu: "250m"
             limits:
-              memory: "512Mi"
-              cpu: "500m"
+              memory: "1024Mi"
+              cpu: "1000m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
## Summary
- DB credentials 평문 → `auth-db-secret` Secret 참조 (secretKeyRef)
- Redis env 추가 (`REDIS_HOST=opentraum-redis.redis`, `REDIS_PORT=6379`)
- resources requests 256Mi/250m, limits 1024Mi/1000m
- `revisionHistoryLimit: 2` 추가
- 라벨 `app.kubernetes.io/name: auth-service` 추가

## Why
#21 에서 1차로 이관한 운영 설정 외에 OpenTraum-Infra `k8s-manual/auth-service/` 에 남아 있던 Secret 참조 / Redis env / resources 운영 값을 본 레포 `k8s/` 로 마저 이관합니다.

## Test plan
- [ ] `auth-db-secret` 클러스터 배포 후 ArgoCD sync 정상 확인
- [ ] 새 Pod env 에 Secret 참조 / Redis 호스트 정상 주입 확인
- [ ] resources requests/limits 변경 반영 확인

Closes #23