### PR TITLE
feat: Refresh Token API 추가 (#26)

### DIFF
--- a/src/main/java/com/opentraum/auth/domain/controller/AuthController.java
+++ b/src/main/java/com/opentraum/auth/domain/controller/AuthController.java
@@ -2,6 +2,7 @@ package com.opentraum.auth.domain.controller;
 
 import com.opentraum.auth.domain.dto.AuthResponse;
 import com.opentraum.auth.domain.dto.LoginRequest;
+import com.opentraum.auth.domain.dto.RefreshRequest;
 import com.opentraum.auth.domain.dto.SignupRequest;
 import com.opentraum.auth.domain.service.AuthService;
 import jakarta.validation.Valid;
@@ -40,6 +41,16 @@ public class AuthController {
     @PostMapping("/login")
     public Mono<ResponseEntity<AuthResponse>> login(@Valid @RequestBody LoginRequest request) {
         return authService.login(request)
+                .map(ResponseEntity::ok);
+    }
+
+    /**
+     * Refresh Token으로 새 access token 발급
+     * POST /api/v1/auth/refresh
+     */
+    @PostMapping("/refresh")
+    public Mono<ResponseEntity<AuthResponse>> refresh(@Valid @RequestBody RefreshRequest request) {
+        return authService.refresh(request.getRefreshToken())
                 .map(ResponseEntity::ok);
     }
 

--- a/src/main/java/com/opentraum/auth/domain/dto/AuthResponse.java
+++ b/src/main/java/com/opentraum/auth/domain/dto/AuthResponse.java
@@ -15,4 +15,5 @@ public class AuthResponse {
     private String role;
     private String tenantId;
     private String token;
+    private String refreshToken;
 }

--- a/src/main/java/com/opentraum/auth/domain/dto/RefreshRequest.java
+++ b/src/main/java/com/opentraum/auth/domain/dto/RefreshRequest.java
@@ -1,0 +1,15 @@
+package com.opentraum.auth.domain.dto;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import jakarta.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class RefreshRequest {
+
+    @Schema(example = "550e8400-e29b-41d4-a716-446655440000")
+    @NotBlank(message = "refreshToken은 필수입니다")
+    private String refreshToken;
+}

--- a/src/main/java/com/opentraum/auth/domain/entity/RefreshToken.java
+++ b/src/main/java/com/opentraum/auth/domain/entity/RefreshToken.java
@@ -1,0 +1,39 @@
+package com.opentraum.auth.domain.entity;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.springframework.data.annotation.Id;
+import org.springframework.data.relational.core.mapping.Column;
+import org.springframework.data.relational.core.mapping.Table;
+
+import java.time.LocalDateTime;
+
+@Table("auth_refresh_tokens")
+@Getter
+@Setter
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class RefreshToken {
+
+    @Id
+    private Long id;
+
+    @Column("user_id")
+    private Long userId;
+
+    @Column("refresh_token")
+    private String refreshToken;
+
+    @Column("tenant_id")
+    private String tenantId;
+
+    @Column("created_at")
+    private LocalDateTime createdAt;
+
+    @Column("expires_at")
+    private LocalDateTime expiresAt;
+}

--- a/src/main/java/com/opentraum/auth/domain/repository/RefreshTokenRepository.java
+++ b/src/main/java/com/opentraum/auth/domain/repository/RefreshTokenRepository.java
@@ -1,0 +1,12 @@
+package com.opentraum.auth.domain.repository;
+
+import com.opentraum.auth.domain.entity.RefreshToken;
+import org.springframework.data.repository.reactive.ReactiveCrudRepository;
+import reactor.core.publisher.Mono;
+
+public interface RefreshTokenRepository extends ReactiveCrudRepository<RefreshToken, Long> {
+
+    Mono<RefreshToken> findByRefreshToken(String refreshToken);
+
+    Mono<Void> deleteByUserId(Long userId);
+}

--- a/src/main/java/com/opentraum/auth/domain/service/AuthService.java
+++ b/src/main/java/com/opentraum/auth/domain/service/AuthService.java
@@ -3,14 +3,17 @@ package com.opentraum.auth.domain.service;
 import com.opentraum.auth.domain.dto.AuthResponse;
 import com.opentraum.auth.domain.dto.LoginRequest;
 import com.opentraum.auth.domain.dto.SignupRequest;
+import com.opentraum.auth.domain.entity.RefreshToken;
 import com.opentraum.auth.domain.entity.Role;
 import com.opentraum.auth.domain.entity.User;
+import com.opentraum.auth.domain.repository.RefreshTokenRepository;
 import com.opentraum.auth.domain.repository.UserRepository;
 import com.opentraum.auth.global.exception.BusinessException;
 import com.opentraum.auth.global.exception.ErrorCode;
 import com.opentraum.auth.global.util.RedisKeyGenerator;
 import com.opentraum.auth.util.JwtProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.redis.core.ReactiveRedisTemplate;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
@@ -26,9 +29,13 @@ import java.util.UUID;
 public class AuthService {
 
     private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
     private final PasswordEncoder passwordEncoder;
     private final JwtProvider jwtProvider;
     private final ReactiveRedisTemplate<String, String> redisTemplate;
+
+    @Value("${jwt.refresh-expiration}")
+    private long refreshExpirationMs;
 
     /**
      * 회원가입
@@ -67,18 +74,20 @@ public class AuthService {
                             .build();
 
                     return userRepository.save(user)
-                            .map(saved -> {
-                                String token = jwtProvider.createToken(
-                                        saved.getId(), saved.getEmail(), saved.getRole(), saved.getTenantId());
-                                return AuthResponse.builder()
-                                        .userId(saved.getId())
-                                        .email(saved.getEmail())
-                                        .name(saved.getName())
-                                        .role(saved.getRole())
-                                        .tenantId(saved.getTenantId())
-                                        .token(token)
-                                        .build();
-                            });
+                            .flatMap(saved -> issueRefreshToken(saved)
+                                    .map(refresh -> {
+                                        String token = jwtProvider.createToken(
+                                                saved.getId(), saved.getEmail(), saved.getRole(), saved.getTenantId());
+                                        return AuthResponse.builder()
+                                                .userId(saved.getId())
+                                                .email(saved.getEmail())
+                                                .name(saved.getName())
+                                                .role(saved.getRole())
+                                                .tenantId(saved.getTenantId())
+                                                .token(token)
+                                                .refreshToken(refresh.getRefreshToken())
+                                                .build();
+                                    }));
                 });
     }
 
@@ -96,17 +105,63 @@ public class AuthService {
                         return Mono.<AuthResponse>error(new BusinessException(ErrorCode.UNAUTHORIZED));
                     }
 
-                    String token = jwtProvider.createToken(
-                            user.getId(), user.getEmail(), user.getRole(), user.getTenantId());
-                    return Mono.just(AuthResponse.builder()
-                            .userId(user.getId())
-                            .email(user.getEmail())
-                            .name(user.getName())
-                            .role(user.getRole())
-                            .tenantId(user.getTenantId())
-                            .token(token)
-                            .build());
+                    return issueRefreshToken(user)
+                            .map(refresh -> {
+                                String token = jwtProvider.createToken(
+                                        user.getId(), user.getEmail(), user.getRole(), user.getTenantId());
+                                return AuthResponse.builder()
+                                        .userId(user.getId())
+                                        .email(user.getEmail())
+                                        .name(user.getName())
+                                        .role(user.getRole())
+                                        .tenantId(user.getTenantId())
+                                        .token(token)
+                                        .refreshToken(refresh.getRefreshToken())
+                                        .build();
+                            });
                 });
+    }
+
+    /**
+     * Refresh Token으로 새 access token 발급.
+     * - DB에서 refresh token 조회 → 만료 체크 → 사용자 조회 → 새 access 발급
+     * - Refresh rotation 안 함 (기존 refresh 그대로 유지)
+     */
+    public Mono<AuthResponse> refresh(String refreshTokenValue) {
+        return refreshTokenRepository.findByRefreshToken(refreshTokenValue)
+                .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.UNAUTHORIZED)))
+                .flatMap(refresh -> {
+                    if (refresh.getExpiresAt().isBefore(LocalDateTime.now())) {
+                        return Mono.<AuthResponse>error(new BusinessException(ErrorCode.UNAUTHORIZED));
+                    }
+                    return userRepository.findById(refresh.getUserId())
+                            .switchIfEmpty(Mono.error(new BusinessException(ErrorCode.UNAUTHORIZED)))
+                            .map(user -> {
+                                String newAccess = jwtProvider.createToken(
+                                        user.getId(), user.getEmail(), user.getRole(), user.getTenantId());
+                                return AuthResponse.builder()
+                                        .userId(user.getId())
+                                        .email(user.getEmail())
+                                        .name(user.getName())
+                                        .role(user.getRole())
+                                        .tenantId(user.getTenantId())
+                                        .token(newAccess)
+                                        .refreshToken(refreshTokenValue)
+                                        .build();
+                            });
+                });
+    }
+
+    private Mono<RefreshToken> issueRefreshToken(User user) {
+        LocalDateTime now = LocalDateTime.now();
+        RefreshToken token = RefreshToken.builder()
+                .userId(user.getId())
+                .refreshToken(UUID.randomUUID().toString())
+                .tenantId(user.getTenantId() != null ? user.getTenantId() : "default")
+                .createdAt(now)
+                .expiresAt(now.plusNanos(refreshExpirationMs * 1_000_000L))
+                .build();
+        return refreshTokenRepository.save(token);
     }
 
     /**

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -23,7 +23,8 @@ spring:
 
 jwt:
   secret: ${JWT_SECRET:opentraum-default-jwt-secret-key-must-be-at-least-256-bits-long-for-hs256}
-  expiration: ${JWT_EXPIRATION:1800000}   # 30분 (밀리초)
+  expiration: ${JWT_EXPIRATION:1800000}                    # access token: 30분 (밀리초)
+  refresh-expiration: ${JWT_REFRESH_EXPIRATION:604800000}  # refresh token: 7일 (밀리초)
 
 springdoc:
   api-docs:


### PR DESCRIPTION
## 배경 / 문제

30분 만료 access token만 발급되고 refresh 메커니즘이 없어 시연 중 토큰 만료 시 강제 재로그인 필요. \`auth_refresh_tokens\` 스키마는 정의되어 있으나 코드는 전무.

이슈: #26

## 디자인

- **Refresh Token**: opaque UUID (DB 조회로 검증)
- **Access Token**: 기존 30분 유지
- **Refresh Expiration**: 7일
- **Rotation**: refresh 호출 시 새 access만, 기존 refresh 유지 (시연 단순성)

## 변경 내용

- 엔티티 \`RefreshToken\` 신규 (\`auth_refresh_tokens\` 매핑)
- \`RefreshTokenRepository\` 신규
- \`RefreshRequest\` DTO 신규
- \`AuthResponse\`에 \`refreshToken\` 필드 추가
- \`AuthService\`:
  - signup/login에서 refresh 발급 + DB save
  - \`refresh(refreshTokenValue)\` 메서드 추가
  - \`issueRefreshToken(user)\` private helper
- \`AuthController\`: POST \`/api/v1/auth/refresh\` 신규
- \`application.yml\`에 \`jwt.refresh-expiration: 604800000\` (7일)

## 검증 (임시 이미지 배포 E2E)

| 케이스 | 결과 |
|---|---|
| signup → access + refresh 둘 다 발급 | ✅ |
| refresh API → 새 access, refresh 그대로 | ✅ |
| 잘못된 refresh → 401 | ✅ |
| login도 refresh 발급 | ✅ |

## Test plan

- [x] Gradle 컴파일
- [x] 임시 이미지 배포 후 E2E 검증
- [ ] (머지 후) CI 빌드 → ArgoCD sync → 정식 이미지 재검증

Closes #26