### PR TITLE
feat: #30 빌드 플랫폼에 linux/arm64 복원

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Amazon ECR 로그인
         uses: aws-actions/amazon-ecr-login@v2
 
+      - name: QEMU 설정
+        uses: docker/setup-qemu-action@v3
+
       - name: Docker Buildx 설정
         uses: docker/setup-buildx-action@v3
 
@@ -42,7 +45,7 @@ jobs:
           context: .
           file: ./Dockerfile
           push: true
-          platforms: linux/amd64
+          platforms: linux/amd64,linux/arm64
           tags: ${{ env.ECR_REGISTRY }}/${{ env.ECR_REPOSITORY }}:${{ github.sha }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
Closes #30

## 변경
- `.github/workflows/cicd.yml`:
  - QEMU step 추가 (`docker/setup-qemu-action@v3`)
  - platforms: `linux/amd64` → `linux/amd64,linux/arm64`

## 배경
ECR 마이그 시 빌드 시간 단축 위해 amd64만으로 줄였으나, 팀원들 모두 Mac으로 작업하는 환경 고려 시 `docker run` 로컬 테스트 케이스에서 막힐 가능성 → arm64 복원.

## 영향
- 빌드 시간 ~2배 (30s → 60s 수준)
- ECR 저장 용량 일부 증가
- 노드(amd64) pull 동작 무영향
- M-series Mac에서 `docker run` 정상 동작