### PR TITLE
chore: CPU limit 정정 (200m → 250m)

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -76,10 +76,10 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "200m"
+              cpu: "250m"
             limits:
               memory: "512Mi"
-              cpu: "200m"
+              cpu: "250m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
Closes #34

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `200m` → `250m`
- `resources.limits.cpu`: `200m` → `250m`

## 영향

- 200m 환경 CrashLoopBackOff 해소 (startup probe 통과 보장)
- 250m 환경 실측 startup 52.31s, probe 한계 65s 대비 마진 +24%
- QoS Guaranteed 유지 (request = limit)
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 교체
