### PR TITLE
chore: CPU limit 정정 (250m → 300m)

### DIFF
--- a/k8s/deployment.yml
+++ b/k8s/deployment.yml
@@ -76,10 +76,10 @@ spec:
           resources:
             requests:
               memory: "512Mi"
-              cpu: "250m"
+              cpu: "300m"
             limits:
               memory: "512Mi"
-              cpu: "250m"
+              cpu: "300m"
           startupProbe:
             httpGet:
               path: /actuator/health


### PR DESCRIPTION
Closes #36

## 변경

### `k8s/deployment.yml`
- `resources.requests.cpu`: `250m` → `300m`
- `resources.limits.cpu`: `250m` → `300m`

## 영향

- 250m 환경 CrashLoopBackOff 가 해소됩니다 (startup 후 Redis health check 통과 보장).
- 300m 환경 추정 startup 47s, probe 한계 65s 대비 마진 +38% 확보됩니다.
- QoS Guaranteed 가 유지됩니다 (request = limit).
- ArgoCD 자동 sync 시 RollingUpdate 로 Pod 가 교체됩니다.